### PR TITLE
refactor: switch from HTTP headers to _meta field for trace context propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2025-10-14
+
+### Changed
+- **BREAKING**: Switched from HTTP headers to `_meta` field for trace context propagation
+- Updated `otel_utils.py` to use `_meta` field convention instead of HTTP headers
+- Modified server tools to accept `_meta` parameter
+- Updated client to inject context into `_meta` field instead of HTTP headers
+- Replaced `with_otel_context_from_headers` decorator with `with_otel_context_from_meta`
+
+### Added
+- `inject_otel_context_to_meta()` utility function for client-side context injection
+- `extract_otel_context_from_meta()` utility function for server-side context extraction
+- Comprehensive documentation on `_meta` approach in README
+- Examples showing JSON-RPC request structure with `_meta` field
+- Comparison table: HTTP headers vs `_meta` field approaches
+- References section with links to MCP spec, OpenTelemetry, and W3C standards
+
+### Benefits
+- **Transport Agnostic**: Now works with stdio, HTTP, and SSE transports
+- **Standards Based**: Follows emerging MCP standard for metadata propagation ([PR #414](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/414))
+- **Interoperable**: Compatible with `openinference-instrumentation-mcp` and other MCP tracing tools
+- **W3C Compatible**: Maintains same W3C Trace Context format (traceparent, tracestate, baggage)
+
+### Migration Guide
+
+#### Before (HTTP headers approach):
+
+**Server:**
+```python
+@mcp.tool()
+@otel_utils.with_otel_context_from_headers
+@observe
+async def get_weather(location: str) -> dict:
+    pass
+```
+
+**Client:**
+```python
+carrier = {}
+inject(carrier)
+transport = StreamableHttpTransport(url="...", headers=carrier)
+await client.call_tool("get_weather", {"location": "NYC"})
+```
+
+#### After (_meta field approach):
+
+**Server:**
+```python
+@mcp.tool()
+@otel_utils.with_otel_context_from_meta
+@observe
+async def get_weather(location: str, _meta: dict | None = None) -> dict:
+    pass
+```
+
+**Client:**
+```python
+from weather_assistant.utils.otel_utils import inject_otel_context_to_meta
+
+meta = inject_otel_context_to_meta()
+await client.call_tool("get_weather", {
+    "location": "NYC",
+    "_meta": meta
+})
+```
+
+## [1.0.0] - 2025-09-27
+
+### Added
+- Initial implementation with HTTP header-based trace context propagation
+- FastMCP server with OpenTelemetry and Langfuse integration
+- Streamlit client for weather assistant
+- Example weather and forecast tools
+- Docker compose setup for local development

--- a/README.md
+++ b/README.md
@@ -8,16 +8,18 @@ A complete example demonstrating distributed tracing in FastMCP applications usi
 
 This repository shows how to:
 - Build MCP servers with proper distributed tracing
-- Propagate OpenTelemetry context via HTTP headers
+- Propagate OpenTelemetry context via MCP `_meta` field (transport-agnostic)
 - Integrate Langfuse for LLM-specific observability
 - Maintain trace hierarchy across client-server boundaries
 
 ## Features
 
 - 🔍 **Distributed Tracing**: Seamless trace context propagation between MCP client and server
+- 🚀 **Transport Agnostic**: Works with stdio, HTTP, and SSE transports via `_meta` field
 - 📊 **LLM Observability**: Track token usage, costs, and latencies with Langfuse
 - 🎯 **Clean Architecture**: Decorator-based approach for minimal code intrusion
 - 🐳 **Docker Ready**: Includes docker-compose setup for local development
+- 🔗 **Standards Based**: Uses W3C Trace Context format and MCP protocol conventions
 
 ## Quick Start
 
@@ -85,34 +87,68 @@ uv run streamlit run weather_assistant/client.py
 
 ## Key Concepts
 
+### Why `_meta` Field Instead of HTTP Headers?
+
+This implementation uses the MCP protocol's `_meta` field for trace context propagation. This approach:
+
+- **Transport Agnostic**: Works with stdio, HTTP, and SSE transports
+- **Standard Convention**: Follows the emerging MCP standard for metadata propagation ([PR #414](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/414))
+- **W3C Compatible**: Uses W3C Trace Context (traceparent, tracestate, baggage)
+- **Interoperable**: Compatible with `openinference-instrumentation-mcp` and other MCP tracing tools
+
 ### Decorator Stack
 
 The key to proper context propagation is the decorator order on MCP tools:
 
 ```python
 @mcp.tool()
-@otel_utils.with_otel_context_from_headers
+@otel_utils.with_otel_context_from_meta
 @observe
-async def get_weather(location: str) -> dict:
+async def get_weather(location: str, _meta: dict | None = None) -> dict:
     # Your tool implementation
 ```
 
 1. `@mcp.tool()` - Registers as MCP tool
-2. `@with_otel_context_from_headers` - Extracts OTel context from HTTP headers
+2. `@with_otel_context_from_meta` - Extracts OTel context from MCP `_meta` field
 3. `@observe` - Creates Langfuse span within the context
 
-### Context Propagation
+### Context Propagation Flow
 
-The client injects trace context into HTTP headers:
+**Client Side:**
 ```python
-carrier = {}
-inject(carrier)  # OpenTelemetry context injection
+from weather_assistant.utils.otel_utils import inject_otel_context_to_meta
 
-transport = StreamableHttpTransport(
-    url="http://localhost:8000/weather",
-    headers=carrier
-)
+# Inject trace context into _meta field
+meta = inject_otel_context_to_meta()
+
+# Pass _meta to tool call
+await client.call_tool("get_weather", {
+    "location": "New York",
+    "_meta": meta
+})
 ```
+
+**JSON-RPC Message Structure:**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "get_weather",
+    "arguments": {
+      "location": "New York"
+    },
+    "_meta": {
+      "traceparent": "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01",
+      "tracestate": "...",
+      "baggage": "..."
+    }
+  }
+}
+```
+
+**Server Side:**
+The `@with_otel_context_from_meta` decorator extracts context from `_meta` and activates it, then Langfuse's `@observe` creates spans within the propagated context.
 
 ## Monitoring
 
@@ -133,6 +169,23 @@ This will install and configure pre-commit hooks that run:
 - Ruff for linting and formatting
 - Basic file checks (trailing whitespace, YAML syntax, etc.)
 - MyPy for type checking
+
+## Comparison: HTTP Headers vs `_meta` Field
+
+| Aspect | HTTP Headers | `_meta` Field |
+|--------|-------------|---------------|
+| Transport Support | HTTP only | All transports (stdio, HTTP, SSE) |
+| Standard | W3C Trace Context | MCP + W3C Trace Context |
+| Implementation | Transport-specific | Protocol-level |
+| Compatibility | HTTP libraries | Any MCP client/server |
+| Use Case | HTTP-only deployments | Universal MCP applications |
+
+## References
+
+- [MCP Specification - `_meta` field convention](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/414)
+- [OpenTelemetry Context Propagation](https://opentelemetry.io/docs/concepts/context-propagation/)
+- [W3C Trace Context](https://www.w3.org/TR/trace-context/)
+- [OpenInference MCP Instrumentation](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-mcp)
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Example of distributed tracing with FastMCP, OpenTelemetry, and L
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "fastmcp>=2.0.0rc1",
+    "fastmcp>=2.12.0",
     "langfuse>=3.0.0",
     "opentelemetry-api>=1.27.0",
     "opentelemetry-sdk>=1.27.0",

--- a/weather_assistant/client.py
+++ b/weather_assistant/client.py
@@ -6,9 +6,9 @@ from fastmcp import Client
 from fastmcp.client import StreamableHttpTransport
 from langfuse import observe
 from opentelemetry import trace
-from opentelemetry.propagate import inject
 
 from weather_assistant.config.tracing import setup_tracing
+from weather_assistant.utils.otel_utils import inject_otel_context_to_meta
 
 # Load environment variables
 load_dotenv()
@@ -22,21 +22,20 @@ tracer = trace.get_tracer(__name__)
 async def handle_weather_request(location: str, forecast_days: int = 3):
     """Handle weather request with distributed tracing."""
 
-    # Prepare carrier for context propagation
-    carrier: dict[str, str] = {}
-    inject(carrier)
+    # Inject trace context into _meta field
+    meta = inject_otel_context_to_meta()
 
-    # Create transport with trace context headers
-    transport = StreamableHttpTransport(url="http://localhost:8000/weather", headers=carrier)
+    # Create transport (no headers needed for trace propagation)
+    transport = StreamableHttpTransport(url="http://localhost:8000/weather")
 
     async with Client(transport) as client:
-        # Get current weather
-        weather_result = await client.call_tool("get_weather", {"location": location})
+        # Get current weather with _meta for trace propagation
+        weather_result = await client.call_tool("get_weather", {"location": location, "_meta": meta})
 
         # Get forecast if requested
         forecast_result = None
         if forecast_days > 0:
-            forecast_result = await client.call_tool("get_forecast", {"location": location, "days": forecast_days})
+            forecast_result = await client.call_tool("get_forecast", {"location": location, "days": forecast_days, "_meta": meta})
 
         return weather_result, forecast_result
 

--- a/weather_assistant/client.py
+++ b/weather_assistant/client.py
@@ -60,14 +60,16 @@ if st.button("Get Weather"):
                 # Run the async function
                 weather, forecast = asyncio.run(handle_weather_request(location, forecast_days))
 
-                # Handle FastMCP response format
-                if isinstance(weather, list) and weather:
-                    # FastMCP returns tool responses as a list of content objects
-                    weather_data = weather[0]
-                    if hasattr(weather_data, "text"):
-                        import json
+                # Handle FastMCP response format - CallToolResult has content attribute
+                import json
 
-                        weather_data = json.loads(weather_data.text)
+                if hasattr(weather, "content"):
+                    # Extract content from CallToolResult
+                    content = weather.content[0] if weather.content else None
+                    if content and hasattr(content, "text"):
+                        weather_data = json.loads(content.text)
+                    else:
+                        weather_data = weather
                 else:
                     weather_data = weather
 
@@ -84,12 +86,13 @@ if st.button("Get Weather"):
                 # Display forecast if requested
                 if forecast and forecast_days > 0:
                     # Handle FastMCP response format for forecast
-                    if isinstance(forecast, list) and forecast:
-                        forecast_data = forecast[0]
-                        if hasattr(forecast_data, "text"):
-                            import json
-
-                            forecast_data = json.loads(forecast_data.text)
+                    if hasattr(forecast, "content"):
+                        # Extract content from CallToolResult
+                        content = forecast.content[0] if forecast.content else None
+                        if content and hasattr(content, "text"):
+                            forecast_data = json.loads(content.text)
+                        else:
+                            forecast_data = forecast
                     else:
                         forecast_data = forecast
 

--- a/weather_assistant/server.py
+++ b/weather_assistant/server.py
@@ -24,17 +24,18 @@ mcp = FastMCP()
 
 
 @mcp.tool()
-@otel_utils.with_otel_context_from_headers
+@otel_utils.with_otel_context_from_meta
 @observe
 async def get_weather(
     location: Annotated[str, "City name to get weather for"],
+    _meta: dict | None = None,
 ) -> Annotated[dict, "Current weather information"]:
     """
     Get current weather for a specified location.
 
     The decorator stack ensures:
     1. @mcp.tool() registers this as an MCP tool
-    2. @with_otel_context_from_headers extracts trace context from HTTP headers
+    2. @with_otel_context_from_meta extracts trace context from MCP _meta field
     3. @observe creates a Langfuse span within the OTel context
     """
     # Simulate weather API call
@@ -50,11 +51,12 @@ async def get_weather(
 
 
 @mcp.tool()
-@otel_utils.with_otel_context_from_headers
+@otel_utils.with_otel_context_from_meta
 @observe
 async def get_forecast(
     location: Annotated[str, "City name for forecast"],
     days: Annotated[int, "Number of days to forecast (1-7)"] = 3,
+    _meta: dict | None = None,
 ) -> Annotated[list, "Weather forecast for the specified days"]:
     """Get weather forecast for the specified location and number of days."""
     forecast = []

--- a/weather_assistant/utils/otel_utils.py
+++ b/weather_assistant/utils/otel_utils.py
@@ -1,61 +1,117 @@
-"""OpenTelemetry utilities for context propagation."""
+"""
+OpenTelemetry context utilities for MCP _meta field propagation.
+
+This module provides utilities for extracting and injecting OpenTelemetry
+context using MCP's _meta field convention, which works across all transport
+types (stdio, HTTP, SSE).
+"""
 
 import asyncio
 import functools
-from contextlib import contextmanager
-from typing import Optional
+from typing import Any, Callable, TypeVar
 
-from opentelemetry import trace
-from opentelemetry.context import attach, detach
-from opentelemetry.propagate import extract
+from opentelemetry import context, propagation
+from opentelemetry.context import Context
+
+F = TypeVar("F", bound=Callable[..., Any])
 
 
-@contextmanager
-def with_otel_context(carrier: Optional[dict[str, str]] = None):
+def extract_otel_context_from_meta(meta: dict | None) -> Context:
     """
-    Context manager that extracts and activates OpenTelemetry context from carrier.
+    Extract OpenTelemetry context from MCP _meta field.
+
+    The _meta field may contain traceparent, tracestate, and baggage
+    following W3C Trace Context specification.
+
+    Args:
+        meta: Dictionary containing trace context fields from MCP request
+
+    Returns:
+        OpenTelemetry context object with extracted trace context
     """
+    if not meta:
+        return context.get_current()
+
+    # Create a carrier dict with the trace context fields
+    carrier = {}
+    if "traceparent" in meta:
+        carrier["traceparent"] = meta["traceparent"]
+    if "tracestate" in meta:
+        carrier["tracestate"] = meta["tracestate"]
+    if "baggage" in meta:
+        carrier["baggage"] = meta["baggage"]
+
+    # Extract context using OpenTelemetry's propagator
     if carrier:
-        # Extract context from carrier
-        ctx = extract(carrier)
-        # Attach the context
-        token = attach(ctx)
-        try:
-            # Get current span from the attached context
-            yield trace.get_current_span()
-        finally:
-            # Detach the context when done
-            detach(token)
-    else:
-        # No carrier provided, just yield current span
-        yield trace.get_current_span()
+        return propagation.extract(carrier)
+    return context.get_current()
 
 
-def with_otel_context_from_headers(func):
+def inject_otel_context_to_meta() -> dict:
     """
-    Decorator that extracts HTTP headers and establishes OpenTelemetry context.
+    Inject current OpenTelemetry context into _meta field format.
 
-    This decorator should be applied before @observe to ensure the context
-    is available when Langfuse creates its spans.
+    This creates a dictionary suitable for use in MCP request params._meta
+    field, containing traceparent, tracestate, and baggage if present.
+
+    Returns:
+        Dictionary with trace context fields for _meta field
     """
+    carrier = {}
+    propagation.inject(carrier, context=context.get_current())
+    return carrier
 
-    @functools.wraps(func)
-    async def async_wrapper(*args, **kwargs):
-        # Import here to avoid circular dependency
-        from fastmcp.server.dependencies import get_http_headers
 
-        headers = get_http_headers()
-        with with_otel_context(headers):
-            return await func(*args, **kwargs)
+def with_otel_context_from_meta(func: F) -> F:
+    """
+    Decorator that extracts OpenTelemetry context from MCP request _meta field
+    and sets it as the current context before executing the function.
+
+    This decorator expects the decorated function to accept a _meta parameter
+    (typically as a keyword argument with default None).
+
+    Usage:
+        @mcp.tool()
+        @with_otel_context_from_meta
+        @observe()
+        def my_tool(arg1: str, _meta: dict = None) -> str:
+            # This function now runs within the propagated trace context
+            return "result"
+
+    Args:
+        func: The function to decorate
+
+    Returns:
+        Decorated function that activates the context from _meta
+    """
 
     @functools.wraps(func)
     def sync_wrapper(*args, **kwargs):
-        # Import here to avoid circular dependency
-        from fastmcp.server.dependencies import get_http_headers
+        # Extract _meta from kwargs
+        meta = kwargs.get("_meta")
 
-        headers = get_http_headers()
-        with with_otel_context(headers):
+        # Extract and activate the context
+        ctx = extract_otel_context_from_meta(meta)
+        token = context.attach(ctx)
+
+        try:
             return func(*args, **kwargs)
+        finally:
+            context.detach(token)
+
+    @functools.wraps(func)
+    async def async_wrapper(*args, **kwargs):
+        # Extract _meta from kwargs
+        meta = kwargs.get("_meta")
+
+        # Extract and activate the context
+        ctx = extract_otel_context_from_meta(meta)
+        token = context.attach(ctx)
+
+        try:
+            return await func(*args, **kwargs)
+        finally:
+            context.detach(token)
 
     # Return appropriate wrapper based on function type
     if asyncio.iscoroutinefunction(func):

--- a/weather_assistant/utils/otel_utils.py
+++ b/weather_assistant/utils/otel_utils.py
@@ -10,8 +10,9 @@ import asyncio
 import functools
 from typing import Any, Callable, TypeVar
 
-from opentelemetry import context, propagation
+from opentelemetry import context
 from opentelemetry.context import Context
+from opentelemetry.propagate import get_global_textmap
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -43,7 +44,8 @@ def extract_otel_context_from_meta(meta: dict | None) -> Context:
 
     # Extract context using OpenTelemetry's propagator
     if carrier:
-        return propagation.extract(carrier)
+        propagator = get_global_textmap()
+        return propagator.extract(carrier)
     return context.get_current()
 
 
@@ -58,7 +60,8 @@ def inject_otel_context_to_meta() -> dict:
         Dictionary with trace context fields for _meta field
     """
     carrier = {}
-    propagation.inject(carrier, context=context.get_current())
+    propagator = get_global_textmap()
+    propagator.inject(carrier, context=context.get_current())
     return carrier
 
 


### PR DESCRIPTION
## Description

This PR refactors the OpenTelemetry context propagation mechanism from HTTP headers to the MCP `_meta` field convention.

## Motivation

The current implementation uses HTTP headers for trace context propagation, which only works with HTTP-based transports. The MCP protocol has an emerging standard for metadata propagation via the `_meta` field (see [PR #414](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/414)), which works across all transport types (stdio, HTTP, SSE).

## Changes

- ✅ Updated `otel_utils.py` with `_meta` field extraction/injection functions
- ✅ Replaced `with_otel_context_from_headers` with `with_otel_context_from_meta` decorator
- ✅ Modified server tools to accept `_meta` parameter
- ✅ Updated client to inject context into `_meta` field instead of headers
- ✅ Added async decorator variant
- ✅ Updated README with comprehensive new approach documentation
- ✅ Added CHANGELOG.md documenting breaking changes and migration guide
- ✅ Fixed OpenTelemetry propagator imports to use `get_global_textmap()`

## Benefits

1. **Transport Agnostic**: Now works with stdio, HTTP, and SSE transports
2. **Standards-Based**: Follows the emerging MCP convention for metadata
3. **Interoperable**: Compatible with `openinference-instrumentation-mcp` and other tools
4. **Maintains W3C Compatibility**: Still uses traceparent/tracestate format

## Breaking Changes

⚠️ This is a breaking change:
- Server tools now require `_meta: dict | None = None` parameter
- Client must use `inject_otel_context_to_meta()` instead of header injection
- Decorator changed from `@with_otel_context_from_headers` to `@with_otel_context_from_meta`

See CHANGELOG.md for detailed migration guide.

## Testing

- [x] Python syntax validation passed
- [x] Code follows existing patterns
- [x] Documentation updated
- [x] Migration guide provided
- [x] Server running successfully with updated code

## Blog Posts

📝 **Original post** (HTTP headers approach): [Distributed Tracing with FastMCP: Combining OpenTelemetry and Langfuse](https://timvw.be/2025/06/27/distributed-tracing-with-fastmcp-combining-opentelemetry-and-langfuse/)

📝 **New follow-up post** (transport-agnostic `_meta` field approach): [FastMCP Distributed Tracing: Transport-Agnostic Context Propagation with _meta](https://timvw.be/2025/10/14/fastmcp-distributed-tracing-transport-agnostic-context-propagation-with-_meta/)

## References

- [MCP _meta convention PR](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/414)
- [OpenInference MCP instrumentation](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-mcp)
- [W3C Trace Context](https://www.w3.org/TR/trace-context/)
- [OpenTelemetry Context Propagation](https://opentelemetry.io/docs/concepts/context-propagation/)